### PR TITLE
fix "FAIR-IMPACT D4.4 report" link on Foreword page

### DIFF
--- a/chapters/0.Foreword.md
+++ b/chapters/0.Foreword.md
@@ -1,6 +1,6 @@
 # Foreword
 
-<p class="callout info">The Executive summary in [FAIR-IMPACT D4.4 report](https://doi.org/10.5281/zenodo.10786147) </p>
+<p markdown="1" class="callout info">The Executive summary in [FAIR-IMPACT D4.4 report](https://doi.org/10.5281/zenodo.10786147) </p>
 The FAIR-IMPACT Guidelines for recommended metadata standards for research software within the EOSC present the first proposal of the Research Software MetaData (RSMD) Guidelines, developed by Task 4.3 (T4.3), Standard metadata for research software, as part of Work Package 4, Metadata and ontologies, in the FAIR-IMPACT project. FAIR-IMPACT aims to realize a FAIR (Findable, Accessible, Interoperable, and Reusable) European Open Science Cloud (EOSC) by leveraging community guidelines and existing infrastructures in the scholarly ecosystem. 
 
 The growing recognition of software's crucial role in research has led to initiatives, infrastructures and research institutions to address the challenges of software findability, accessibility, attribution and reuse. One of these initiatives, the Scholarly Infrastructures for Research Software (SIRS) Task Force (TF), identified in its report (EOSC Executive Board & EOSC Secretariat, 2020) the general need for actionable, standardized guidelines for researchers/developers that self-archive software or submit software for publication.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,3 +31,4 @@ markdown_extensions:
    guess_lang: false
 - pymdownx.tasklist:
       custom_checkbox: true
+- markdown.extensions.md_in_html


### PR DESCRIPTION
this commit enables the extension "markdown.extensions.md_in_html" in order to properly render markdown links inside HTML code, such as the example below:

   <p markdown="1">
      [this link](http://this.link.example]
   </p>

docs for the "markdown.extensions.md_in_html":

- https://python-markdown.github.io/extensions/md_in_html