### PR TITLE
add one empty line before a markdown list

### DIFF
--- a/chapters/1.General.md
+++ b/chapters/1.General.md
@@ -14,6 +14,7 @@ Provide embedded information about software in the code itself as a metadata fil
 **Essential ☆☆☆**
 
 Issue a metadata record (extrinsic metadata) about the source code in a publicly available infrastructure to benefit from the infrastructure metadata service (such as citation exports and search functionalities):
+
 * scholarly repository (e.g HAL, Zenodo, etc.)
 * publisher (e.g IPOL, eLife, [Dagstuhl](https://www.dagstuhl.de/), etc.)
 * registry/ aggregator (e.g ASCL, swMath, WikiData, DataCite, bio.tools, etc.)

--- a/chapters/4.Description_Classification.md
+++ b/chapters/4.Description_Classification.md
@@ -38,6 +38,7 @@ Add descriptive metadata of the software in a machine readable format, for examp
 **Useful ☆**
 
 Add descriptive information in README file or other intrinsic metadata file as proposed in community standards (e.g [Software Release Practice HOWTO](https://www.tldp.org/HOWTO/html_single/Software-Release-Practice-HOWTO/)  and [Make a README](https://www.makeareadme.com/)):
+
 * Website 
 * Link to the documentation 
 * Contact & support

--- a/chapters/5.Credit_Attribution.md
+++ b/chapters/5.Credit_Attribution.md
@@ -23,6 +23,7 @@ Use people identifiers for non-ambiguous attribution (ORCID, ID-HAL, ID-REF, GPG
 **Important ☆☆**
 
 Use roles for software actors (authors & contributors). Refer to existing contributor roles if possible:
+
 * https://allcontributors.org/
 * [CRediT](https://credit.niso.org/) – Contributor Roles Taxonomy (niso.org)
 * [SORTÆD](https://sdruskat.net/software-authorship/): Software Role Taxonomy and Authorship Definition 
@@ -39,6 +40,7 @@ Provide citation preference (CITATION.cff file, Citation section in README, .bib
 Where applicable, use appropriate citation granularity level (software, software-module, software-version, code-fragment) by referring to the BibLaTeX software package specifications.
 
 See:
+
 * https://ctan.org/pkg/biblatex-software; 
 * https://fr.overleaf.com/learn/latex/Bibliography_management_with_biblatex 
 


### PR DESCRIPTION
this Pull Request fix the HTML rendering for the HTML list items on the chapters:
- General Metadata Recommendations
- Description Classification
- Credit Attribution