### PR TITLE
add eScience and Helmholtz RSD directory

### DIFF
--- a/chapters/1.General.md
+++ b/chapters/1.General.md
@@ -17,6 +17,7 @@ Issue a metadata record (extrinsic metadata) about the source code in a publicly
 * scholarly repository (e.g HAL, Zenodo, etc.)
 * publisher (e.g IPOL, eLife, [Dagstuhl](https://www.dagstuhl.de/), etc.)
 * registry/ aggregator (e.g ASCL, swMath, WikiData, DataCite, bio.tools, etc.)
+* directory (e.g [eScience RSD](https://research.software), [Helmholtz RSD](https://helmholtz.software), etc.)
 
 
 ### RSMD-1.3


### PR DESCRIPTION
this commit adds Research Software Directory (RSD) to the to recommendation RSMD-1.2 on "General Metadata Recommendations" page as an additional service to the list of infrastructure metadata services

links added:
- eScience RSD: https://research.software
- Helmholtz RSD: https://helmholtz.software